### PR TITLE
.github/workflows/release.yml に書き込み権限の設定を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
このプル リクエストには、`.github/workflows/release.yml` ファイルへの小さな変更が含まれています。この変更により、リリース プロセス中にコンテンツを書き込むための権限が追加されます。

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R10): リリース プロセス中にコンテンツを書き込むための `permissions` セクションを追加しました。