### PR TITLE
VSCode設定を更新：バッチファイルのEOLを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "java.configuration.updateBuildConfiguration": "automatic",
     "[bat]": {
         "files.encoding": "shiftjis",
-        "files.autoGuessEncoding": false
-    },
-    "files.autoGuessEncoding": false
+        "files.autoGuessEncoding": false,
+        "files.eol": "\r\n"
+    }
 }


### PR DESCRIPTION
- .bat ファイルの改行コード（EOL）を Windows 形式（\r\n）に設定